### PR TITLE
[FEATURE] Doktype is now filter on default

### DIFF
--- a/Classes/Builder/RecordListNodeBuilder.php
+++ b/Classes/Builder/RecordListNodeBuilder.php
@@ -18,10 +18,14 @@ class RecordListNodeBuilder implements NodeBuilderInterface
 {
     protected TableConfiguration $table;
 
+    /**
+     * @param iterable<RecordListNodeExtenderInterface> $extenders
+     */
     public function __construct(
         protected RecordListTypeBuilder $recordListTypeBuilder,
         protected OrderItemInputType $orderFieldType,
-        protected FilterInputType $filterInputType
+        protected FilterInputType $filterInputType,
+        protected iterable $extenders
     ) {
     }
 
@@ -59,6 +63,12 @@ class RecordListNodeBuilder implements NodeBuilderInterface
 
         if ($this->table->hasLanguage()) {
             $arguments = $arguments->add(GraphqlArgument::create('language')->withType(Type::string()));
+        }
+
+        foreach ($this->extenders as $extender) {
+            if ($extender->supportsTable($this->table)) {
+                $arguments = $extender->extend($this->table, $arguments);
+            }
         }
 
         return GraphqlNode::create($this->table->getCamelPluralName())

--- a/Classes/Builder/RecordListNodeExtenderInterface.php
+++ b/Classes/Builder/RecordListNodeExtenderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RozbehSharahi\Graphql3\Builder;
+
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlArgumentCollection;
+use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
+
+interface RecordListNodeExtenderInterface
+{
+    public function supportsTable(TableConfiguration $table): bool;
+
+    public function extend(TableConfiguration $table, GraphqlArgumentCollection $arguments): GraphqlArgumentCollection;
+}

--- a/Classes/Builder/RecordNodeExtenderInterface.php
+++ b/Classes/Builder/RecordNodeExtenderInterface.php
@@ -4,27 +4,12 @@ declare(strict_types=1);
 
 namespace RozbehSharahi\Graphql3\Builder;
 
-use RozbehSharahi\Graphql3\Domain\Model\GraphqlArgumentCollection;
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlArgumentCollection as Arguments;
 use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 interface RecordNodeExtenderInterface
 {
-    public function supportsTable(
-        TableConfiguration $table
-    ): bool;
+    public function supportsTable(TableConfiguration $table): bool;
 
-    public function extendArguments(
-        TableConfiguration $table,
-        GraphqlArgumentCollection $arguments
-    ): GraphqlArgumentCollection;
-
-    /**
-     * @param array<string, mixed> $arguments
-     */
-    public function extendQuery(
-        TableConfiguration $table,
-        QueryBuilder $query,
-        array $arguments
-    ): QueryBuilder;
+    public function extendArguments(TableConfiguration $table, Arguments $arguments): Arguments;
 }

--- a/Classes/Domain/Model/ListRequest.php
+++ b/Classes/Domain/Model/ListRequest.php
@@ -58,6 +58,16 @@ class ListRequest
         return $clone;
     }
 
+    public function hasArgument(string $name): bool
+    {
+        return array_key_exists($name, $this->arguments);
+    }
+
+    public function getArgument(string $name): mixed
+    {
+        return $this->arguments[$name];
+    }
+
     public function getQueryModifier(): \Closure
     {
         return $this->queryModifier;

--- a/Classes/Domain/Model/Tca/ColumnConfiguration.php
+++ b/Classes/Domain/Model/Tca/ColumnConfiguration.php
@@ -144,6 +144,11 @@ class ColumnConfiguration
         return 'select' === $this->getType() && 'selectSingle' === $this->getRenderType() && $this->getForeignTable();
     }
 
+    public function isSingleSelect(): bool
+    {
+        return 'select' === $this->getType() && 'selectSingle' === $this->getRenderType() && !$this->getForeignTable();
+    }
+
     public function isLanguage(): bool
     {
         return 'language' === $this->getType();

--- a/Classes/Extender/DoktypeFilterRecordListNodeExtender.php
+++ b/Classes/Extender/DoktypeFilterRecordListNodeExtender.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RozbehSharahi\Graphql3\Extender;
+
+use GraphQL\Type\Definition\Type;
+use RozbehSharahi\Graphql3\Builder\RecordListNodeExtenderInterface;
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlArgument;
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlArgumentCollection;
+use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
+
+class DoktypeFilterRecordListNodeExtender implements RecordListNodeExtenderInterface
+{
+    public function supportsTable(TableConfiguration $table): bool
+    {
+        return 'pages' === $table->getName();
+    }
+
+    public function extend(TableConfiguration $table, GraphqlArgumentCollection $arguments): GraphqlArgumentCollection
+    {
+        return $arguments->add(
+            GraphqlArgument::create('allDoktypes')
+                ->withType(Type::nonNull(Type::boolean()))
+                ->withDefaultValue(false)
+        );
+    }
+}

--- a/Classes/Extender/DoktypeFilterRecordListResolverExtender.php
+++ b/Classes/Extender/DoktypeFilterRecordListResolverExtender.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RozbehSharahi\Graphql3\Extender;
+
+use RozbehSharahi\Graphql3\Domain\Model\ListRequest;
+use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
+use RozbehSharahi\Graphql3\Resolver\RecordListResolverExtenderInterface;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+
+class DoktypeFilterRecordListResolverExtender implements RecordListResolverExtenderInterface
+{
+    public function supports(TableConfiguration $table): bool
+    {
+        return 'pages' === $table->getName();
+    }
+
+    public function extend(TableConfiguration $table, ListRequest $request, QueryBuilder $query): QueryBuilder
+    {
+        if ($request->hasArgument('allDoktypes') && $request->getArgument('allDoktypes')) {
+            return $query;
+        }
+
+        return $query->andWhere(
+            $query->expr()->in('doktype', [
+                '0',
+                PageRepository::DOKTYPE_DEFAULT,
+                PageRepository::DOKTYPE_LINK,
+                PageRepository::DOKTYPE_SHORTCUT,
+                PageRepository::DOKTYPE_SPACER,
+            ])
+        );
+    }
+}

--- a/Classes/FieldCreator/SingleSelectFieldCreator.php
+++ b/Classes/FieldCreator/SingleSelectFieldCreator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RozbehSharahi\Graphql3\FieldCreator;
+
+use GraphQL\Type\Definition\Type;
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlNode;
+use RozbehSharahi\Graphql3\Domain\Model\Record;
+use RozbehSharahi\Graphql3\Domain\Model\Tca\ColumnConfiguration;
+
+class SingleSelectFieldCreator implements FieldCreatorInterface
+{
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function supportsField(ColumnConfiguration $column): bool
+    {
+        return $column->isSingleSelect();
+    }
+
+    public function createField(ColumnConfiguration $column): GraphqlNode
+    {
+        return GraphqlNode::create()
+            ->withName($column->getGraphqlName())
+            ->withType(Type::string())
+            ->withResolver(fn (Record $record) => $record->get($column))
+        ;
+    }
+}

--- a/Classes/Resolver/RecordListResolverExtenderInterface.php
+++ b/Classes/Resolver/RecordListResolverExtenderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RozbehSharahi\Graphql3\Resolver;
+
+use RozbehSharahi\Graphql3\Domain\Model\ListRequest;
+use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+interface RecordListResolverExtenderInterface
+{
+    public function supports(TableConfiguration $table): bool;
+
+    public function extend(TableConfiguration $table, ListRequest $request, QueryBuilder $query): QueryBuilder;
+}

--- a/Classes/Resolver/RecordResolver.php
+++ b/Classes/Resolver/RecordResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace RozbehSharahi\Graphql3\Resolver;
 
-use RozbehSharahi\Graphql3\Builder\RecordNodeExtenderInterface;
 use RozbehSharahi\Graphql3\Domain\Model\ItemRequest;
 use RozbehSharahi\Graphql3\Domain\Model\Record;
 use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
@@ -17,13 +16,9 @@ class RecordResolver
 {
     protected TableConfiguration $table;
 
-    /**
-     * @param iterable<RecordNodeExtenderInterface> $extenders
-     */
     public function __construct(
         protected ConnectionPool $connectionPool,
-        protected AccessChecker $accessChecker,
-        protected iterable $extenders,
+        protected AccessChecker $accessChecker
     ) {
     }
 
@@ -60,12 +55,6 @@ class RecordResolver
         $query = $this->createQuery();
         $query->where($query->expr()->eq('uid', $query->createNamedParameter($identifier)));
         $this->applyPublicRequestFilters($query, $request);
-
-        foreach ($this->extenders as $extender) {
-            if ($extender->supportsTable($this->table)) {
-                $query = $extender->extendQuery($this->table, $query, $request->getArguments());
-            }
-        }
 
         try {
             $row = $query->executeQuery()->fetchAssociative();

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -6,6 +6,7 @@ namespace RozbehSharahi\Graphql3;
 use RozbehSharahi\Graphql3\Builder\LanguageListNodeBuilder;
 use RozbehSharahi\Graphql3\Builder\LanguageNodeBuilder;
 use RozbehSharahi\Graphql3\Builder\RecordListNodeBuilder;
+use RozbehSharahi\Graphql3\Builder\RecordListNodeExtenderInterface;
 use RozbehSharahi\Graphql3\Builder\RecordNodeBuilder;
 use RozbehSharahi\Graphql3\Builder\RecordNodeExtenderInterface;
 use RozbehSharahi\Graphql3\Builder\RecordTypeBuilder;
@@ -13,6 +14,7 @@ use RozbehSharahi\Graphql3\Builder\RecordTypeBuilderExtenderInterface;
 use RozbehSharahi\Graphql3\Controller\GraphqlController;
 use RozbehSharahi\Graphql3\FieldCreator\FieldCreatorInterface;
 use RozbehSharahi\Graphql3\Registry\SchemaRegistry;
+use RozbehSharahi\Graphql3\Resolver\RecordListResolverExtenderInterface;
 use RozbehSharahi\Graphql3\Resolver\RecordResolver;
 use RozbehSharahi\Graphql3\Security\AccessChecker;
 use RozbehSharahi\Graphql3\Security\JwtManager;
@@ -55,6 +57,14 @@ return static function (ContainerConfigurator $container, ContainerBuilder $cont
     $containerBuilder
         ->registerForAutoconfiguration(RecordTypeBuilderExtenderInterface::class)
         ->addTag('graphql3.record_type_builder_extender');
+
+    $containerBuilder
+        ->registerForAutoconfiguration(RecordListResolverExtenderInterface::class)
+        ->addTag('graphql3.record_list_resolver_extender');
+
+    $containerBuilder
+        ->registerForAutoconfiguration(RecordListNodeExtenderInterface::class)
+        ->addTag('graphql3.record_list_node_extender');
 
     if(Environment::getContext()->isTesting()) {
         $containerBuilder->registerForAutoconfiguration(RecordTypeBuilder::class)->setPublic(true);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -24,9 +24,13 @@ services:
     arguments:
       $extenders: !tagged_iterator graphql3.record_node_extender
 
-  RozbehSharahi\Graphql3\Resolver\RecordResolver:
+  RozbehSharahi\Graphql3\Builder\RecordListNodeBuilder:
     arguments:
-      $extenders: !tagged_iterator graphql3.record_node_extender
+      $extenders: !tagged_iterator graphql3.record_list_node_extender
+
+  RozbehSharahi\Graphql3\Resolver\RecordListResolver:
+    arguments:
+      $extenders: !tagged_iterator graphql3.record_list_resolver_extender
 
   RozbehSharahi\Graphql3\Security\AccessChecker:
     arguments:


### PR DESCRIPTION
The record-list-resolver now filters (via extender) page-doktypes to be either:

- not set
- default
- shortcut
- link
- spacer

Also:

- [x] It is possible deactivate the filter per argument allDoktypes

Within this commit the record-resolver extendQuery was removed in favor of creating a dedicated record-resolver-extender in the future.