### PR TITLE
[TASK] Introduce jwt algorithm EdDSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,18 +646,19 @@ know in an Issue-Entry on Github if you happen to need such.**
 
 ##### Jwt auth setup / configuration
 
-Currently `graphql3` only supports following algorithms:
+Currently `graphql3` supports following algorithms:
 
 - [x] RS256
 - [x] RS256 with password secured secret
 - [x] HS256
+- [x] EdDSA
 
 Following env vars you will need to set. If no public key is defined it will fall back to private key for
 none-asymmetric signatures as HS256.
 
 - [x] Private key (needed for creating tokens, for instance `vendor/bin/typo3 graphql3:create-token:manual`)
 - [x] Public key (needed on some algorithms like RS256 for validating tokens)
-- [x] Algorithm (for instance RS256, HS256, default RS256)
+- [x] Algorithm (for instance RS256, HS256, EdDSA, default RS256)
 - [x] Passphrase (needed if private key is password encrypted)
 
 The following example configuration should be the most common setup:

--- a/Tests/Functional/SecurityTest.php
+++ b/Tests/Functional/SecurityTest.php
@@ -98,6 +98,16 @@ class SecurityTest extends TestCase
                 null,
                 null,
             ],
+            'EdDSA' => (static function () {
+                $sodiumKeyPair = sodium_crypto_sign_keypair();
+
+                return [
+                    JwtManager::ALGORITHM_ED_DSA,
+                    base64_encode(sodium_crypto_sign_secretkey($sodiumKeyPair)),
+                    base64_encode(sodium_crypto_sign_publickey($sodiumKeyPair)),
+                    null,
+                ];
+            })(),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "ext-pdo": "*",
-        "ext-openssl": "*",
         "typo3/cms-core": "^12.0",
         "typo3/cms-backend": "^12.0",
         "typo3/cms-frontend": "^12.0",
@@ -22,6 +21,8 @@
         "firebase/php-jwt": "^6.3.0"
     },
     "require-dev": {
+        "ext-openssl": "*",
+        "ext-sodium": "*",
         "roave/security-advisories": "dev-latest",
         "typo3/cms-install": "^12.0",
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
also moved dependency to ext-sodium and ext-openssl to dev as project shall decide themselves on the algorithm and do not need all extensions installed.

Instead, good error handling was introduced.