### PR TITLE
[BUGFIX] RecordTypeBuilder::resolveFlexFormNode should always resolve…

### DIFF
--- a/Classes/Builder/RecordTypeBuilder.php
+++ b/Classes/Builder/RecordTypeBuilder.php
@@ -88,13 +88,7 @@ class RecordTypeBuilder implements TypeBuilderInterface
                             throw new InternalErrorException(sprintf(self::ERROR_INVALID_FLEX_FORM_POINTER, $column->getFullName()));
                         }
 
-                        $node = $this->resolveFlexFormNode($column);
-
-                        if (!$node) {
-                            continue;
-                        }
-
-                        $fields = $fields->add($node);
+                        $fields = $fields->add($this->resolveFlexFormNode($column));
                     }
 
                     foreach ($this->extenders as $extender) {
@@ -123,12 +117,8 @@ class RecordTypeBuilder implements TypeBuilderInterface
         return null;
     }
 
-    protected function resolveFlexFormNode(ColumnConfiguration $column): ?GraphqlNode
+    protected function resolveFlexFormNode(ColumnConfiguration $column): GraphqlNode
     {
-        if (!$column->isGraphqlActive()) {
-            return null;
-        }
-
         foreach ($this->flexFormFieldCreators as $flexFormFieldCreator) {
             if ($flexFormFieldCreator->supportsField($column)) {
                 return $flexFormFieldCreator->createField($column);


### PR DESCRIPTION
… or throw exception

The field graphql-active is not needed flex-form-columns for now, as one could simply not create the configuration. If it should ever be needed, this change can also be reverted.