### PR TITLE
[FIX] Fixed content rendering returning empty string on TYPO3 v12.1.*

### DIFF
--- a/Classes/Command/CreateTokenFrontendUserCommand.php
+++ b/Classes/Command/CreateTokenFrontendUserCommand.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Exception;
 use RozbehSharahi\Graphql3\Domain\Model\JwtUser;
 use RozbehSharahi\Graphql3\Security\JwtManager;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -59,10 +58,5 @@ class CreateTokenFrontendUserCommand extends Command
         $output->writeln($token);
 
         return Command::SUCCESS;
-    }
-
-    protected function getQuestionHelper(): QuestionHelper
-    {
-        return $this->getHelper('question');
     }
 }

--- a/Classes/Command/CreateTokenManualCommand.php
+++ b/Classes/Command/CreateTokenManualCommand.php
@@ -53,6 +53,12 @@ class CreateTokenManualCommand extends Command
 
     protected function getQuestionHelper(): QuestionHelper
     {
-        return $this->getHelper('question');
+        $helper = $this->getHelper('question');
+
+        if (!$helper instanceof QuestionHelper) {
+            throw new \RuntimeException('Unexpected helper received in '.__METHOD__);
+        }
+
+        return $helper;
     }
 }

--- a/Classes/Environment/Typo3Environment.php
+++ b/Classes/Environment/Typo3Environment.php
@@ -13,8 +13,17 @@ class Typo3Environment
         return (int) explode('.', VersionNumberUtility::getCurrentTypo3Version())[0];
     }
 
-    public function isVersion(int $version): bool
+    public function getSecondLevelVersion(): int
     {
+        return (int) explode('.', VersionNumberUtility::getCurrentTypo3Version())[1];
+    }
+
+    public function isVersion(int $version, int $secondLevelVersion = null): bool
+    {
+        if ($secondLevelVersion && $secondLevelVersion !== $this->getSecondLevelVersion()) {
+            return false;
+        }
+
         return $this->getMainVersion() === $version;
     }
 }

--- a/Classes/Extender/ContentRenderRecordTypeBuilderExtender.php
+++ b/Classes/Extender/ContentRenderRecordTypeBuilderExtender.php
@@ -1,10 +1,13 @@
 <?php
 
+/** @noinspection DuplicatedCode */
+
 declare(strict_types=1);
 
 namespace RozbehSharahi\Graphql3\Extender;
 
 use GraphQL\Type\Definition\Type;
+use Psr\Http\Message\ServerRequestInterface;
 use RozbehSharahi\Graphql3\Builder\RecordTypeBuilderExtenderInterface;
 use RozbehSharahi\Graphql3\Domain\Model\GraphqlNode;
 use RozbehSharahi\Graphql3\Domain\Model\GraphqlNodeCollection;
@@ -17,8 +20,10 @@ use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Site\Entity\SiteInterface;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -28,7 +33,11 @@ class ContentRenderRecordTypeBuilderExtender implements RecordTypeBuilderExtende
 
     public const ERROR_COULD_NOT_RESOLVE_SITE = 'No site available for content rendering.';
 
+    public const ERROR_COULD_NOT_RESOLVE_FRONTEND_USER_ASPECT = 'No frontend user aspect was available on request object';
+
     public const ERROR_UNEXPECTED_DIRECT_RESPONSE = 'TSFE gave a direct response on determineId. Is there a page that conflicts with your graphql3 route?';
+
+    public const ERROR_UNEXPECTED_TYPO3_CORE_CODE = 'Content rendering on graphql3 is very different on each typo3 version. However an unexpected state of core code was detected on runtime.';
 
     public function __construct(protected CurrentSession $currentSession, protected Typo3Environment $typo3Environment)
     {
@@ -45,65 +54,98 @@ class ContentRenderRecordTypeBuilderExtender implements RecordTypeBuilderExtende
             ->withName('rendered')
             ->withType(Type::string())
             ->withResolver(function (Record $record) {
-                return $this->run(function () use ($record) {
-                    $request = $this->currentSession->getRequest();
-                    $tsfe = $this->initFrontendController($request, $record);
-                    $renderer = $this->createRendererByFrontendController($tsfe);
+                $request = $this->currentSession->getRequest();
+                $site = $request->getAttribute('site');
+                $frontendUser = $request->getAttribute('frontend.user');
+                $language = $record->getLanguage();
+                $pageId = $record->getPid();
 
-                    $renderedContent = $renderer->cObjGetSingle('RECORDS', [
-                        'tables' => 'tt_content',
-                        'source' => $record->getUid(),
-                        'dontCheckPid' => 1,
-                    ]);
+                if (!$site instanceof SiteInterface) {
+                    throw new InternalErrorException(self::ERROR_COULD_NOT_RESOLVE_SITE);
+                }
 
-                    // now it gets wicked, we replace the uncached markers INT_script
-                    $tsfe->content = $renderedContent;
-                    $tsfe->cObj = $renderer;
-                    $tsfe->config['INTincScript'] ??= [];
-                    $tsfe->config['INTincScript_ext'] ??= [];
-                    $tsfe->config['INTincScript_ext']['divKey'] ??= null;
-                    $tsfe->INTincScript($this->currentSession->getRequest());
-                    $renderedContent = $tsfe->content;
+                if (!$frontendUser instanceof FrontendUserAuthentication) {
+                    throw new InternalErrorException(self::ERROR_COULD_NOT_RESOLVE_FRONTEND_USER_ASPECT);
+                }
 
-                    $tsfe->releaseLocks();
+                $tsfe = $this->createFrontendController($site, $language, $pageId, $frontendUser);
 
-                    RootlineUtility::purgeCaches();
+                if ($this->typo3Environment->isVersion(12, 1)) {
+                    return $this->renderContentVersion12Point1($tsfe, $request, $record);
+                }
 
-                    return $renderedContent;
-                });
+                if ($this->typo3Environment->isVersion(12, 0)) {
+                    return $this->renderContentVersion12Point0($tsfe, $request, $record);
+                }
+
+                if ($this->typo3Environment->isVersion(11)) {
+                    return $this->renderContentVersion11($tsfe, $request, $record);
+                }
+
+                throw new InternalErrorException('Unsupported typo3 version for graphql3.');
             })
         ;
 
         return $nodes->add($node);
     }
 
-    protected function initFrontendController(ServerRequest $request, Record $record): TypoScriptFrontendController
-    {
-        $site = $request->getAttribute('site');
-        $language = $record->getLanguage();
-        $pageArguments = new PageArguments($record->getPid(), '0', []);
-
-        if (!$site instanceof SiteInterface) {
-            throw new InternalErrorException(self::ERROR_COULD_NOT_RESOLVE_SITE);
-        }
-
-        $tsfe = GeneralUtility::makeInstance(
-            TypoScriptFrontendController::class,
-            GeneralUtility::makeInstance(Context::class),
-            $site,
-            $language,
-            $pageArguments,
-            $request->getAttribute('frontend.user')
-        );
-
+    protected function renderContentVersion12Point1(
+        TypoScriptFrontendController $tsfe,
+        ServerRequestInterface $request,
+        Record $record
+    ): string {
         $directResponse = $tsfe->determineId($request);
+
         if ($directResponse) {
             throw new InternalErrorException(self::ERROR_UNEXPECTED_DIRECT_RESPONSE);
         }
 
-        // Should not be here !
-        $GLOBALS['TSFE'] = $tsfe;
-        $GLOBALS['TYPO3_REQUEST'] = $request;
+        try {
+            $request = $tsfe->getFromCache($request);
+        } catch (\Throwable $e) {
+            throw new InternalErrorException(self::ERROR_COULD_NOT_CREATE_FRONTEND_CONTROLLER.': '.$e->getMessage());
+        }
+
+        $renderer = $this->createRenderer($tsfe);
+        $renderer->setRequest($request);
+
+        $renderedContent = $renderer->cObjGetSingle('RECORDS', [
+            'tables' => 'tt_content',
+            'source' => $record->getUid(),
+            'dontCheckPid' => 1,
+        ]);
+
+        // now it gets wicked, we replace the uncached markers INT_script
+        $tsfe->content = $renderedContent;
+        $tsfe->cObj = $renderer;
+        $tsfe->config['INTincScript'] ??= [];
+        $tsfe->config['INTincScript_ext'] ??= [];
+        $tsfe->config['INTincScript_ext']['divKey'] ??= null;
+
+        // The run method will make sure to rollback tsfe and typo3_request globals
+        $renderedContent = $this->run(function () use ($tsfe, $request) {
+            $GLOBALS['TSFE'] = $tsfe;
+            $GLOBALS['TYPO3_REQUEST'] = $request;
+            $tsfe->INTincScript($request);
+
+            return $tsfe->content;
+        });
+
+        $tsfe->releaseLocks();
+
+        return $renderedContent;
+    }
+
+    protected function renderContentVersion12Point0(
+        TypoScriptFrontendController $tsfe,
+        ServerRequestInterface $request,
+        Record $record
+    ): string {
+        $directResponse = $tsfe->determineId($request);
+
+        if ($directResponse) {
+            throw new InternalErrorException(self::ERROR_UNEXPECTED_DIRECT_RESPONSE);
+        }
 
         try {
             $tsfe->getFromCache($request);
@@ -111,17 +153,100 @@ class ContentRenderRecordTypeBuilderExtender implements RecordTypeBuilderExtende
             throw new InternalErrorException(self::ERROR_COULD_NOT_CREATE_FRONTEND_CONTROLLER.': '.$e->getMessage());
         }
 
-        if ($this->typo3Environment->isVersion(11)) {
-            try {
-                $tsfe->getConfigArray($request);
-            } catch (\Throwable $e) {
-                throw new InternalErrorException(self::ERROR_COULD_NOT_CREATE_FRONTEND_CONTROLLER.': '.$e->getMessage());
-            }
-        }
+        $renderer = $this->createRenderer($tsfe);
+        $renderer->setRequest($request);
 
-        return $tsfe;
+        $renderedContent = $renderer->cObjGetSingle('RECORDS', [
+            'tables' => 'tt_content',
+            'source' => $record->getUid(),
+            'dontCheckPid' => 1,
+        ]);
+
+        // now it gets wicked, we replace the uncached markers INT_script
+        $tsfe->content = $renderedContent;
+        $tsfe->cObj = $renderer;
+        $tsfe->config['INTincScript'] ??= [];
+        $tsfe->config['INTincScript_ext'] ??= [];
+        $tsfe->config['INTincScript_ext']['divKey'] ??= null;
+
+        // The run method will make sure to rollback tsfe and typo3_request globals
+        $renderedContent = $this->run(function () use ($tsfe, $request) {
+            $GLOBALS['TSFE'] = $tsfe;
+            $GLOBALS['TYPO3_REQUEST'] = $request;
+            $tsfe->INTincScript($request);
+
+            return $tsfe->content;
+        });
+
+        $tsfe->releaseLocks();
+
+        RootlineUtility::{'purgeCaches'}();
+
+        return $renderedContent;
     }
 
+    protected function renderContentVersion11(
+        TypoScriptFrontendController $tsfe,
+        ServerRequest $request,
+        Record $record
+    ): string {
+        $directResponse = $tsfe->determineId($request);
+
+        if ($directResponse) {
+            throw new InternalErrorException(self::ERROR_UNEXPECTED_DIRECT_RESPONSE);
+        }
+
+        try {
+            $tsfe->getFromCache($request);
+        } catch (\Throwable $e) {
+            throw new InternalErrorException(self::ERROR_COULD_NOT_CREATE_FRONTEND_CONTROLLER.': '.$e->getMessage());
+        }
+
+        if (!method_exists($tsfe, 'getConfigArray')) {
+            throw new InternalErrorException(self::ERROR_UNEXPECTED_TYPO3_CORE_CODE);
+        }
+
+        try {
+            $tsfe->getConfigArray($request);
+        } catch (\Throwable $e) {
+            throw new InternalErrorException(self::ERROR_COULD_NOT_CREATE_FRONTEND_CONTROLLER.': '.$e->getMessage());
+        }
+
+        $renderer = $this->createRenderer($tsfe);
+        $renderer->setRequest($request);
+
+        $renderedContent = $renderer->cObjGetSingle('RECORDS', [
+            'tables' => 'tt_content',
+            'source' => $record->getUid(),
+            'dontCheckPid' => 1,
+        ]);
+
+        // now it gets wicked, we replace the uncached markers INT_script
+        $tsfe->content = $renderedContent;
+        $tsfe->cObj = $renderer;
+        $tsfe->config['INTincScript'] ??= [];
+        $tsfe->config['INTincScript_ext'] ??= [];
+        $tsfe->config['INTincScript_ext']['divKey'] ??= null;
+
+        // The run method will make sure to rollback tsfe and typo3_request globals
+        $renderedContent = $this->run(function () use ($tsfe, $request) {
+            $GLOBALS['TSFE'] = $tsfe;
+            $GLOBALS['TYPO3_REQUEST'] = $request;
+            $tsfe->INTincScript($request);
+
+            return $tsfe->content;
+        });
+
+        $tsfe->releaseLocks();
+
+        RootlineUtility::{'purgeCaches'}();
+
+        return $renderedContent;
+    }
+
+    /**
+     * Will make sure we roll back changes to tsfe and typo3_request globals.
+     */
     protected function run(\Closure $job): mixed
     {
         $tsfeBackup = $GLOBALS['TSFE'] ?? null;
@@ -135,8 +260,24 @@ class ContentRenderRecordTypeBuilderExtender implements RecordTypeBuilderExtende
         return $result ?? null;
     }
 
-    protected function createRendererByFrontendController(TypoScriptFrontendController $tsfe): ContentObjectRenderer
+    protected function createRenderer(TypoScriptFrontendController $tsfe): ContentObjectRenderer
     {
         return GeneralUtility::makeInstance(ContentObjectRenderer::class, $tsfe);
+    }
+
+    private function createFrontendController(
+        SiteInterface $site,
+        SiteLanguage $language,
+        int $pageId,
+        FrontendUserAuthentication $frontendUser
+    ): TypoScriptFrontendController {
+        return GeneralUtility::makeInstance(
+            TypoScriptFrontendController::class,
+            GeneralUtility::makeInstance(Context::class),
+            $site,
+            $language,
+            new PageArguments($pageId, '0', []),
+            $frontendUser
+        );
     }
 }

--- a/Tests/Fixture/TestApplication/typo3-v11/config/sites/main/config.yaml
+++ b/Tests/Fixture/TestApplication/typo3-v11/config/sites/main/config.yaml
@@ -1,5 +1,5 @@
 base: 'http://localhost:8080/'
-errorHandling: {  }
+errorHandling: []
 languages:
   -
     title: English
@@ -20,10 +20,10 @@ languages:
     base: /de/
     typo3Language: de
     locale: de_DE.UTF-8
-    iso-639-1: en
+    iso-639-1: de
     navigationTitle: Deutsch
     hreflang: de-de
     direction: ltr
     flag: de
 rootPageId: 1
-routes: {  }
+routes: []

--- a/Tests/Fixture/TestApplication/typo3-v12/config/sites/main/config.yaml
+++ b/Tests/Fixture/TestApplication/typo3-v12/config/sites/main/config.yaml
@@ -1,5 +1,5 @@
 base: 'http://localhost:8080/'
-errorHandling: {  }
+errorHandling: []
 languages:
   -
     title: English
@@ -27,4 +27,4 @@ languages:
     flag: de
 
 rootPageId: 1
-routes: {  }
+routes: []

--- a/Tests/Functional/Core/FunctionScopeBuilder.php
+++ b/Tests/Functional/Core/FunctionScopeBuilder.php
@@ -29,7 +29,6 @@ use TYPO3\CMS\Core\Database\Schema\SqlReader;
 use TYPO3\CMS\Core\Middleware\VerifyHostHeader;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Http\Application;
 
 class FunctionScopeBuilder
@@ -434,7 +433,6 @@ class FunctionScopeBuilder
 
         $siteFinder->getAllSites(false);
 
-        RootlineUtility::purgeCaches();
         GeneralUtility::makeInstance(CacheManager::class)->getCache('rootline')->flush();
 
         return $this;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       - PHP_IDE_CONFIG=serverName=graphql3
       - GRAPHQL3_JWT_PRIVATE_KEY=file://Tests/Fixture/KeyPairs/Rs256/private.pem
       - GRAPHQL3_JWT_PUBLIC_KEY=file://Tests/Fixture/KeyPairs/Rs256/public.pem
+      - TYPO3_CONTEXT=Development/Docker
     volumes:
       - './:/var/www/html'
     ports:


### PR DESCRIPTION
Content rendering on TYPO3 is not easy on runtime. Imagine to content of two different pages with complete different typo-script configuration on each page.

Furthermore, with each version of TYPO3 the api of TSFE is changing. Therefore, I split up the content-render-record type in multiple methods dedicated to a specific typo3 version.

By this compatibility for 12.1 is also provided, where a couple of methods of TYPO3 have changed:

- RootlineUtility::purgeCaches was removed
- $tsfe->getFromCache now returns a request with typo-script object as an attribute, which needs to be passed to content object renderer.