### PR TITLE
[BUGFIX] Fix content-renderer compatibility to Typo3 version > 12.1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: sed -i 's/\^11\.5 || \^12/^${{ matrix.version }}/g' composer.json
       - run: composer install
-      - run: vendor/bin/php-cs-fixer fix --dry-run
+      - run: tools/php-cs-fixer fix --dry-run
       - run: vendor/bin/phpstan
       - run: vendor/bin/phpunit
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /composer.*.lock
 /.phpunit.result.cache
 /.php-cs-fixer.cache
+/tools/lib

--- a/Classes/Builder/RecordNodeBuilder.php
+++ b/Classes/Builder/RecordNodeBuilder.php
@@ -90,7 +90,8 @@ class RecordNodeBuilder implements NodeBuilderInterface
 
         return fn ($_, $args) => $this
             ->recordResolver
-            ->for($this->table)->resolve(ItemRequest::create($args));
+            ->for($this->table)->resolve(ItemRequest::create($args))
+        ;
     }
 
     protected function assertTable(): self

--- a/Classes/Environment/Typo3Environment.php
+++ b/Classes/Environment/Typo3Environment.php
@@ -20,10 +20,15 @@ class Typo3Environment
 
     public function isVersion(int $version, int $secondLevelVersion = null): bool
     {
-        if ($secondLevelVersion && $secondLevelVersion !== $this->getSecondLevelVersion()) {
+        if (null !== $secondLevelVersion && $secondLevelVersion !== $this->getSecondLevelVersion()) {
             return false;
         }
 
         return $this->getMainVersion() === $version;
+    }
+
+    public function isGreaterOrEqualVersion(int $version, int $secondLevelVersion = 0): bool
+    {
+        return $this->getMainVersion() >= $version && $this->getSecondLevelVersion() >= $secondLevelVersion;
     }
 }

--- a/Classes/Extender/ContentRenderRecordTypeBuilderExtender.php
+++ b/Classes/Extender/ContentRenderRecordTypeBuilderExtender.php
@@ -70,7 +70,7 @@ class ContentRenderRecordTypeBuilderExtender implements RecordTypeBuilderExtende
 
                 $tsfe = $this->createFrontendController($site, $language, $pageId, $frontendUser);
 
-                if ($this->typo3Environment->isVersion(12, 1)) {
+                if ($this->typo3Environment->isGreaterOrEqualVersion(12, 1)) {
                     return $this->renderContentVersion12Point1($tsfe, $request, $record);
                 }
 

--- a/Tests/Functional/SecurityTest.php
+++ b/Tests/Functional/SecurityTest.php
@@ -65,7 +65,7 @@ class SecurityTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    public function canCreateJwtTokenDataProvider(): array
+    public static function canCreateJwtTokenDataProvider(): array
     {
         return [
             'rs256' => [

--- a/bin/php-cs-fixer
+++ b/bin/php-cs-fixer
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-bin/docker exec app php vendor/bin/php-cs-fixer "$@"
+bin/docker exec app tools/php-cs-fixer "$@"

--- a/bin/test
+++ b/bin/test
@@ -3,4 +3,8 @@
 bin/cache-clear
 bin/php-cs-fixer fix
 bin/phpstan
+
+echo "Wait 1 sec for tests"
+sleep 1
+
 bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "typo3/cms-extensionmanager": "^11.5 || ^12",
         "webonyx/graphql-php": "^v15.0.1",
         "symfony/security-core": "^v6.0.14",
-        "doctrine/inflector": "2.0.6",
+        "doctrine/inflector": "^2.0.6",
         "firebase/php-jwt": "^6.3.0"
     },
     "require-dev": {
@@ -38,8 +38,7 @@
         "typo3/cms-felogin": "^11.5 || ^12",
         "typo3/cms-fluid-styled-content": "^11.5 || ^12",
         "rozbehsharahi/graphql3-test-extension": "@dev",
-        "phpunit/phpunit": "^9",
-        "friendsofphp/php-cs-fixer": "dev-master",
+        "phpunit/phpunit": "^10",
         "phpstan/phpstan": "1.8.x-dev"
     },
     "config": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,18 @@
-<phpunit>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd">
     <testsuites>
         <testsuite name="functional">
             <directory>Tests/Functional</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <coverage/>
+    <source>
         <include>
             <directory suffix=".php">Classes</directory>
         </include>
-    </coverage>
+    </source>
+    <php>
+        <ini name="display_errors" value="true"/>
+    </php>
 </phpunit>

--- a/tools/php-cs-fixer
+++ b/tools/php-cs-fixer
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p tools/lib/php-cs-fixer
+composer require --dev --working-dir=tools/lib/php-cs-fixer friendsofphp/php-cs-fixer
+tools/lib/php-cs-fixer/vendor/bin/php-cs-fixer "$@"


### PR DESCRIPTION
Newer versions like 12.2 would not be catched in ContentRenderRecordTypeBuilderExtender.php as it was only checking version 12.1 and there was a bug on Typo3Environment::isVersion method. This resulted into an error complaining about missing purgeCaches which should never be called above 12.1.

---

Further: php-cs-fixer is no longer part of main package, it is instead install on-the-fly within tools directory.

This way we avoid composer conflicts to effect the application, which are only related to php-cs-fixer.

Also phpunit is now updated to version 10