### PR TITLE
Sorting field and cors

### DIFF
--- a/Classes/Controller/GraphqlController.php
+++ b/Classes/Controller/GraphqlController.php
@@ -49,6 +49,7 @@ class GraphqlController
         $response = $this->responseFactory
             ->createResponse()
             ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Access-Control-Allow-Origin', '*')
         ;
 
         try {

--- a/Classes/Domain/Model/Tca/TableConfiguration.php
+++ b/Classes/Domain/Model/Tca/TableConfiguration.php
@@ -128,6 +128,16 @@ class TableConfiguration
         return !empty($this->configuration['ctrl']['languageField']);
     }
 
+    public function hasSortingField(): bool
+    {
+        return !empty($this->configuration['ctrl']['sortby']);
+    }
+
+    public function getSortingField(): string
+    {
+        return $this->configuration['ctrl']['sortby'];
+    }
+
     public function hasAccessControl(): bool
     {
         return !empty($this->configuration['ctrl']['enablecolumns']['fe_group']);

--- a/Classes/Extender/SortingRecordTypeBuilderExtender.php
+++ b/Classes/Extender/SortingRecordTypeBuilderExtender.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RozbehSharahi\Graphql3\Extender;
+
+use GraphQL\Type\Definition\Type;
+use RozbehSharahi\Graphql3\Builder\RecordTypeBuilderExtenderInterface;
+use RozbehSharahi\Graphql3\Converter\CaseConverter;
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlNode;
+use RozbehSharahi\Graphql3\Domain\Model\GraphqlNodeCollection;
+use RozbehSharahi\Graphql3\Domain\Model\Record;
+use RozbehSharahi\Graphql3\Domain\Model\Tca\TableConfiguration;
+
+class SortingRecordTypeBuilderExtender implements RecordTypeBuilderExtenderInterface
+{
+    public function __construct(protected CaseConverter $caseConverter)
+    {
+    }
+
+    public function supportsTable(TableConfiguration $table): bool
+    {
+        return $table->hasSortingField();
+    }
+
+    public function extendNodes(TableConfiguration $table, GraphqlNodeCollection $nodes): GraphqlNodeCollection
+    {
+        return $nodes->add(
+            GraphqlNode::create()
+                ->withName($this->caseConverter->toCamel($table->getSortingField()))
+                ->withType(Type::int())
+                ->withResolver(fn (Record $record) => $record->get($table->getSortingField()))
+        );
+    }
+}

--- a/Tests/Functional/GraphqlRequestTest.php
+++ b/Tests/Functional/GraphqlRequestTest.php
@@ -130,4 +130,22 @@ class GraphqlRequestTest extends TestCase
 
         self::assertEquals(404, $response->getStatusCode());
     }
+
+    public function testCanControlCorsHeaders(): void
+    {
+        $scope = $this->getFunctionalScopeBuilder()->build();
+
+        $scope->get(SchemaRegistry::class)->registerCreator(fn () => new Schema([
+            'query' => new NoopQueryType(),
+        ]));
+
+        $response = $scope->graphqlRequest('{
+            noop
+        }');
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertSame('noop', $response->get('data.noop'));
+        self::assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+        self::assertEquals('*', $response->getHeaderLine('Access-Control-Allow-Origin'));
+    }
 }

--- a/Tests/Functional/RecordTypeBuilderTest.php
+++ b/Tests/Functional/RecordTypeBuilderTest.php
@@ -71,10 +71,11 @@ class RecordTypeBuilderTest extends TestCase
             ]),
         ]));
 
-        $response = $scope->doGraphqlRequest('{
+        $response = $scope->graphqlRequest('{
             page {
                 title
                 slug
+                sorting
                 parentPage { title }
                 languageParent { title }
                 createdAt(format: "Y-m-d")
@@ -85,14 +86,15 @@ class RecordTypeBuilderTest extends TestCase
             }
         }');
 
-        self::assertSame('root-page', $response['data']['page']['title']);
-        self::assertNull($response['data']['page']['languageParent']);
-        self::assertNull($response['data']['page']['parentPage']);
-        self::assertSame('1980-09-18', $response['data']['page']['createdAt']);
-        self::assertSame('1980-09-18', $response['data']['page']['updatedAt']);
-        self::assertFalse($response['data']['page']['hidden']);
-        self::assertFalse($response['data']['page']['deleted']);
-        self::assertTrue($response['data']['page']['navigationHide']);
+        self::assertSame('root-page', $response->get('data.page.title'));
+        self::assertNull($response->get('data.page.languageParent'));
+        self::assertNull($response->get('data.page.parentPage'));
+        self::assertSame('1980-09-18', $response->get('data.page.createdAt'));
+        self::assertSame('1980-09-18', $response->get('data.page.updatedAt'));
+        self::assertFalse($response->get('data.page.hidden'));
+        self::assertFalse($response->get('data.page.deleted'));
+        self::assertTrue($response->get('data.page.navigationHide'));
+        self::assertIsInt($response->get('data.page.sorting'));
     }
 
     public function testCanResolveParentPage(): void

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "ext-pdo": "*",
         "ext-dom": "*",
         "typo3/cms-core": "^11.5 || ^12",


### PR DESCRIPTION
- Sorting field is now part of record-type-builder
- CORS header is set to allow cross domain access of graphql endpoint